### PR TITLE
add new taxon products attribute

### DIFF
--- a/my-project/src/components/modules/taxon-products.json
+++ b/my-project/src/components/modules/taxon-products.json
@@ -43,6 +43,9 @@
     },
     "hr": {
       "type": "boolean"
+    },
+    "is_algolia_personalization": {
+      "type": "boolean"
     }
   }
 }

--- a/my-project/src/components/modules/taxon-products.json
+++ b/my-project/src/components/modules/taxon-products.json
@@ -46,6 +46,10 @@
     },
     "is_algolia_personalization": {
       "type": "boolean"
+    },
+    "product_limit": {
+      "type": "integer",
+      "default": 4
     }
   }
 }


### PR DESCRIPTION
Danny added an attribute to the taxon products module. this adds that to the component and updates the attribute to fit our new format (removes module name from attribute)

looks like I missed an attribute in the original work as well

lets not merge until that work is done